### PR TITLE
Stop mount_afp segfaulting & minor changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # Libraries
 *.lib
 *.a
+*.la
+*.lo
 
 # Shared objects (inc. Windows DLLs)
 *.dll
@@ -15,3 +17,13 @@
 *.exe
 *.out
 *.app
+
+# Build directories & generated files
+.deps
+.libs
+Makefile
+config.h
+config.log
+config.status
+libtool
+

--- a/fuse/commands.c
+++ b/fuse/commands.c
@@ -512,14 +512,14 @@ static int process_mount(struct fuse_client * c)
 				break;
 			default:
 				log_for_client((void *)c,AFPFSD,LOG_ERR,
-					"Mounting of volume %s of server %s failed.\n", 
+					"Mounting of volume %s from server %s failed.\n", 
 						volume->volume_name_printable, 
 						volume->server->server_name_printable);
 			}
 			goto error;
 		} else {
 			log_for_client((void *)c,AFPFSD,LOG_NOTICE,
-				"Mounting of volume %s of server %s succeeded.\n", 
+				"Mounting of volume %s from server %s succeeded.\n", 
 					volume->volume_name_printable, 
 					volume->server->server_name_printable);
 			return 0;

--- a/lib/proto_map.c
+++ b/lib/proto_map.c
@@ -122,7 +122,7 @@ int afp_mapid_reply(struct afp_server *server, char * buf, unsigned int size, vo
 
 	if (reply->header.return_code.error_code!=kFPNoErr) return -1;
 
-	copy_from_pascal_two(name,reply->name,255);
+	copy_from_pascal_two(name, &reply->name, 255);
 
 	return 0;
 }


### PR DESCRIPTION
Correctly pass a pointer when handling a mapid_reply.
Change text slightly for connection messages.
Improve the scope of .gitignore.
